### PR TITLE
Removes 'master' and adds 1.12 and 1.13 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ dist: trusty
 
 go:
   - 1.11.x
-  - master
-
+  - 1.12.x
+  - 1.13.x
+  
 script: make all
 
 env:


### PR DESCRIPTION
Used to speed up tests on travis and still test against multiple versions